### PR TITLE
Remove panel button background color.

### DIFF
--- a/PRO-dark-XFCE-4.14/gtk-3.0/gtk.css
+++ b/PRO-dark-XFCE-4.14/gtk-3.0/gtk.css
@@ -13385,7 +13385,6 @@ XfceHeading {
 .xfce4-panel.background button {
 
   background-image: none;
-  background-color: #37383d;
   border-radius: 0;
   border: none;
   box-shadow: none;


### PR DESCRIPTION
The color assignment was causing background on the panel icons to be different than the actual panel background.
Before:
![image](https://user-images.githubusercontent.com/38758281/68048613-38112680-fce1-11e9-80e9-df1bbe773c1b.png)

After:
![image](https://user-images.githubusercontent.com/38758281/68083282-3fdae300-fe27-11e9-9d32-0b5085724af7.png)
